### PR TITLE
Fix infinite recursion for aliases in pkgs/top-level/python-aliases.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -221,6 +221,16 @@ lib.makeScope pkgs.newScope (self: {
         getFunctorFn
         (
           [
+            # Remove Python packages aliases with non-normalized names to avoid issues with infinite recursion (issue #750).
+            (self: super: lib.attrsets.mapAttrs
+              (
+                name: value:
+                  if lib.isDerivation value && self.hasPythonModule value && (normalizePackageName name) != name
+                  then null
+                  else value
+              )
+              super)
+
             (
               self: super:
                 {

--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -59,9 +59,6 @@ let
 
 in
 lib.composeManyExtensions [
-  # normalize all the names
-  (self: super: poetryLib.normalizePackageSet super)
-
   # NixOps
   (self: super:
     lib.mapAttrs (_: v: addBuildSystem { inherit self; drv = v; attr = "poetry"; }) (lib.filterAttrs (n: _: lib.strings.hasPrefix "nixops" n) super)


### PR DESCRIPTION
This fixes #750.